### PR TITLE
Remove extraneous dependency in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@roshub/api",
   "private": false,
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "src/node-roshub.js",
   "browser": "src/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "parse-url": "^5.0.1",
     "prompt": "^1.0.0",
     "roslib": "^0.20.0",
-    "roslibjs": "github:RobotWebTools/roslibjs.git",
     "sanitize-filename": "^1.6.3",
     "store-js": "^2.0.4",
     "touch": "^3.1.0",


### PR DESCRIPTION
this dependency can cause build errors when running `npm i` offline, and it is not used by the package.